### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/src/runtime/composables/useCookieConsent.ts
+++ b/src/runtime/composables/useCookieConsent.ts
@@ -21,13 +21,13 @@ export function useCookieConsent(): NuxtCookieConsentUseCookieConsent {
 }
 
 export function cookieConsentRenew(): void {
-  if (process.client) {
+  if (import.meta.client) {
     window?.CookieConsent?.renew?.()
   }
 }
 
 export function cookieConsentShow(): void {
-  if (process.client) {
+  if (import.meta.client) {
     window?.CookieConsent?.show?.()
   }
 }

--- a/src/runtime/plugins/cookiebot.plugin.ts
+++ b/src/runtime/plugins/cookiebot.plugin.ts
@@ -76,7 +76,7 @@ export default defineNuxtPlugin(() => {
     })
   }
 
-  if (process.client) {
+  if (import.meta.client) {
     window.addEventListener('CookiebotOnAccept', () => {
       if (!window?.Cookiebot?.consent) {
         return

--- a/src/runtime/plugins/cookieinformation.plugin.ts
+++ b/src/runtime/plugins/cookieinformation.plugin.ts
@@ -69,7 +69,7 @@ export default defineNuxtPlugin(() => {
     })
   }
 
-  if (process.client) {
+  if (import.meta.client) {
     window.addEventListener('CookieInformationConsentGiven', () => {
       if (!window?.CookieInformation?.getConsentGivenFor) {
         return


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)