### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -22,20 +22,9 @@ This means that your scripts are loaded initially by the client if the consent i
 
 ## Installation
 Install the `@weareheavy/nuxt-cookie-consent` module using your favorite package manager.
-
-::: code-group
-```bash [npm]
-npm install @weareheavy/nuxt-cookie-consent
+```bash
+npx nuxi@latest module add nuxt-cookie-consent
 ```
-
-```bash [yarn]
-yarn add @weareheavy/nuxt-cookie-consent
-```
-
-```bash [bun]
-bun install @weareheavy/nuxt-cookie-consent
-```
-:::
 
 ## Initialize module
 Add the module to your `nuxt.config.ts` file.


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
